### PR TITLE
Workflow screenshot on PR ready

### DIFF
--- a/.github/workflows/pr-html-screenshot.yml
+++ b/.github/workflows/pr-html-screenshot.yml
@@ -1,0 +1,64 @@
+name: HTML-Preview
+
+on:
+  pull_request:
+    types: [ ready_for_review ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  screenshot:
+    name: Take screenshot
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Setup saxonb-xslt, python, gettext
+        run: sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends libsaxonb-java python-libxml2 gettext -y
+
+      - name: Build html docs
+        run: |
+          make -j$(nproc)
+
+
+      - id: files
+        name: Get changed xml files
+        uses: Ana06/get-changed-files@v2.1.0
+        with:
+          # Format of the steps output context.
+          # Can be 'space-delimited', 'csv', or 'json'.
+          # Default: 'space-delimited'
+          format: 'json'
+          # Filter files using a glob filter
+          filter: 'sdk/**/*.xml'
+
+      - id: filelist
+        name: Build list with changed html files
+        run: |
+          readarray -t files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.added_modified }}')"
+          for file in ${files[@]}; do
+            htmlfile=$(echo "${file}" | sed 's/sdk/online\/de\/sdk/; s/.xml/.html/')
+            echo "Adding ${htmlfile}"
+            htmlfiles="${htmlfiles}${htmlfile}, " 
+          done
+          htmlfiles=${htmlfiles::-2}
+          echo $htmlfiles
+          echo "::set-output name=htmlfiles::${htmlfiles}"
+
+      # Run Screenshot Comment Action
+      - name: Take screenshots of changed html files and add to pull request
+        uses: saadmk11/comment-webpage-screenshot@v0.5
+        with:
+          upload_to: github_branch
+          # Capture Screenshots of Changed HTML Files
+          capture_changed_html_files: no
+          # Comma seperated paths to any other HTML File
+          capture_html_file_paths: "${{ steps.filelist.outputs.htmlfiles }}"


### PR DESCRIPTION
This workflow introduces a automatic screenshot feature to assist the reviewers in pull requests. Examples see below. Triggered only when the PR goes from draft to ready for review.

First 3 screenshots show an example of broken design as CSS wasn't linked correctly.